### PR TITLE
Add feature bridge with diagnostics and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# futu_autotrade
+
+This is a simplified demonstration project.
+
+## 模型输入体检与常见错误
+
+通过 `debug_probe.py` 可以对模型输入进行体检，常见问题包括列缺失、`NaN`/`inf` 值、数据类型不一致等。`bridge.build_latest_feature_row` 会自动补齐缺列并将异常值填充为 `0`，同时通过 Prometheus 指标 `features_nan_rate` 记录替换比例。

--- a/RUN.md
+++ b/RUN.md
@@ -1,0 +1,9 @@
+# 运行指南
+
+```bash
+pip install -r requirements.txt
+python debug_probe.py --config ./config.yaml
+python stream_runner.py
+```
+
+Prometheus 指标默认暴露在 `http://localhost:8000`。

--- a/bridge.py
+++ b/bridge.py
@@ -1,0 +1,90 @@
+"""Feature bridge ensures model-ready inputs.
+
+This module sanitises raw indicator DataFrames into a single row of
+`float32` features ordered according to `config.yaml`'s
+`features.cols`.  Missing columns are filled with ``0``, invalid values
+(`NaN`/``inf``) are replaced with ``0`` and the result is forced into a
+shape of ``(1, n)``.  A Prometheus gauge ``features_nan_rate`` records
+how many values were cleaned.  If after cleaning the data is still
+invalid, :class:`FeatureBridgeError` is raised.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+import logging
+
+import numpy as np
+import pandas as pd
+
+from metrics import features_nan_rate
+
+LOGGER = logging.getLogger(__name__)
+
+
+class FeatureBridgeError(RuntimeError):
+    """Raised when the feature bridge cannot produce a valid feature row."""
+
+
+@dataclass
+class BridgeReport:
+    missing_cols: List[str]
+    nan_ratio: float
+    shape: tuple
+    dtype: str
+
+
+def _clean_dataframe(df: pd.DataFrame, feature_cols: Iterable[str]) -> pd.DataFrame:
+    df = df.copy()
+    for col in feature_cols:
+        if col not in df.columns:
+            LOGGER.warning("missing column %s, filling with 0", col)
+            df[col] = 0.0
+    df = df[feature_cols]
+    # Coerce to numeric and replace non-finite values
+    df = df.apply(pd.to_numeric, errors="coerce").fillna(0.0)
+    df.replace([np.inf, -np.inf], 0.0, inplace=True)
+    return df
+
+
+def build_latest_feature_row(df: pd.DataFrame, feature_cols: Iterable[str]) -> np.ndarray:
+    """Return the latest feature row as ``float32``.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing raw feature columns.
+    feature_cols:
+        Ordered list of required feature columns.
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape ``(1, n)`` with ``float32`` dtype.
+
+    Raises
+    ------
+    FeatureBridgeError
+        If the resulting array cannot be coerced into the required
+        shape or dtype.
+    """
+    feature_cols = list(feature_cols)
+    cleaned = _clean_dataframe(df, feature_cols)
+    missing_cols = [c for c in feature_cols if c not in df.columns]
+
+    latest = cleaned.tail(1)
+    arr = latest.to_numpy(dtype=np.float32, copy=False)
+    nan_count = np.isnan(arr).sum() + np.isinf(arr).sum()
+    if nan_count:
+        LOGGER.warning("found %d NaN/inf values, filled with 0", nan_count)
+    arr = np.nan_to_num(arr, copy=False)
+    features_nan_rate.set(nan_count / arr.size)
+
+    if arr.shape != (1, len(feature_cols)):
+        raise FeatureBridgeError(
+            f"feature row shape {arr.shape} != (1, {len(feature_cols)})"
+        )
+    if arr.dtype != np.float32:
+        raise FeatureBridgeError(f"feature row dtype {arr.dtype} != float32")
+
+    return arr

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,2 @@
+features:
+  cols: [price, volume, macd, bbands]

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -1,0 +1,20 @@
+"""Mock data fetcher for examples and tests."""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def fetch_latest_data() -> pd.DataFrame:
+    """Return a DataFrame with the latest market data.
+
+    This mock implementation produces a single row with fixed values
+    suitable for tests and demonstration.
+    """
+    return pd.DataFrame(
+        {
+            "price": [1.0],
+            "volume": [100],
+            "macd": [0.1],
+            "bbands": [0.2],
+        }
+    )

--- a/debug_probe.py
+++ b/debug_probe.py
@@ -1,0 +1,55 @@
+"""Run a one-shot feature extraction and output diagnostics."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+import pandas as pd
+import yaml
+
+import data_fetcher
+from bridge import FeatureBridgeError, build_latest_feature_row
+
+LOGGER = logging.getLogger(__name__)
+
+
+def run(config_path: str) -> None:
+    """Execute the debug probe.
+
+    Parameters
+    ----------
+    config_path: str
+        Path to the YAML configuration file.
+    """
+    with open(config_path, "r", encoding="utf8") as fh:
+        config = yaml.safe_load(fh)
+    feature_cols = config["features"]["cols"]
+
+    raw_df = data_fetcher.fetch_latest_data()
+    try:
+        X = build_latest_feature_row(raw_df, feature_cols)
+    except FeatureBridgeError as err:
+        LOGGER.exception("feature bridge failed: %s", err)
+        raise
+
+    report: Dict[str, Any] = {
+        "columns": feature_cols,
+        "dtype": str(X.dtype),
+        "shape": X.shape,
+    }
+    Path("debug_X.npy").write_bytes(X.tobytes())
+    with open("debug_report.json", "w", encoding="utf8") as fh:
+        json.dump(report, fh, indent=2)
+    LOGGER.info("debug probe complete: %s", report)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True, help="path to config.yaml")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+    run(args.config)

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,5 @@
+"""Prometheus metrics for feature bridge."""
+from prometheus_client import Gauge
+
+# Gauge for percentage of NaN/inf replaced in feature row
+features_nan_rate: Gauge = Gauge("features_nan_rate", "Rate of NaN/inf features in latest row")

--- a/model_service.py
+++ b/model_service.py
@@ -1,0 +1,9 @@
+"""Trivial model service for demonstration purposes."""
+from __future__ import annotations
+
+import numpy as np
+
+
+def predict_proba_one(x: np.ndarray) -> float:
+    """Return a dummy probability for the given feature row."""
+    return float(1 / (1 + np.exp(-x.sum())))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+pandas
+PyYAML
+prometheus-client

--- a/stream_runner.py
+++ b/stream_runner.py
@@ -1,0 +1,43 @@
+"""Simple stream runner tying together data fetch, bridge and model."""
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+import yaml
+from prometheus_client import start_http_server
+
+import data_fetcher
+from bridge import FeatureBridgeError, build_latest_feature_row
+from metrics import features_nan_rate
+import model_service
+
+LOGGER = logging.getLogger(__name__)
+
+
+def run_once(feature_cols: Iterable[str]) -> float:
+    """Fetch data, build feature row and run the model."""
+    raw_df = data_fetcher.fetch_latest_data()
+    LOGGER.debug("raw columns: %s", list(raw_df.columns))
+    try:
+        X = build_latest_feature_row(raw_df, feature_cols)
+    except FeatureBridgeError as err:
+        LOGGER.warning("feature bridge failed: %s", err)
+        raise
+    LOGGER.debug("feature row shape=%s dtype=%s", X.shape, X.dtype)
+    return model_service.predict_proba_one(X)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    with open("config.yaml", "r", encoding="utf8") as fh:
+        config = yaml.safe_load(fh)
+    feature_cols = config["features"]["cols"]
+
+    start_http_server(8000)
+    prob = run_once(feature_cols)
+    LOGGER.info("prediction %.3f, nan rate %.3f", prob, features_nan_rate._value.get())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pandas as pd
+
+from bridge import build_latest_feature_row
+
+
+FEATURE_COLS = ["price", "volume", "macd", "bbands"]
+
+
+def test_bridge_cleaning_handles_missing_and_nan():
+    df = pd.DataFrame({
+        "price": [1.0],
+        "volume": [np.nan],
+        "macd": ["3"],
+        # bbands missing
+    })
+    arr = build_latest_feature_row(df, FEATURE_COLS)
+    assert arr.shape == (1, len(FEATURE_COLS))
+    assert arr.dtype == np.float32
+    assert arr[0, 1] == 0.0  # NaN replaced
+    assert arr[0, 3] == 0.0  # missing column filled

--- a/tests/test_debug_probe.py
+++ b/tests/test_debug_probe.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+import debug_probe
+import data_fetcher
+
+
+def test_debug_probe_outputs(tmp_path, monkeypatch):
+    def fake_fetch() -> pd.DataFrame:
+        return pd.DataFrame({"price": [1.0], "volume": [2.0], "macd": [3.0], "bbands": [4.0]})
+    monkeypatch.setattr(data_fetcher, "fetch_latest_data", fake_fetch)
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("features:\n  cols: [price, volume, macd, bbands]\n")
+    monkeypatch.chdir(tmp_path)
+
+    debug_probe.run(str(cfg))
+
+    assert Path("debug_X.npy").exists()
+    report = json.loads(Path("debug_report.json").read_text())
+    assert report["dtype"] == "float32"
+    assert report["shape"] == [1, 4] or tuple(report["shape"]) == (1, 4)

--- a/tests/test_stream_runner.py
+++ b/tests/test_stream_runner.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+import data_fetcher
+import model_service
+import stream_runner
+from metrics import features_nan_rate
+
+
+def test_stream_runner(monkeypatch):
+    monkeypatch.setattr(data_fetcher, "fetch_latest_data", lambda: pd.DataFrame({
+        "price": [1.0],
+        "volume": [2.0],
+        "macd": [3.0],
+        "bbands": [4.0],
+    }))
+    monkeypatch.setattr(model_service, "predict_proba_one", lambda x: 0.5)
+    prob = stream_runner.run_once(["price", "volume", "macd", "bbands"])
+    assert prob == 0.5
+    assert features_nan_rate._value.get() == 0.0


### PR DESCRIPTION
## Summary
- add feature bridge enforcing shape/dtype and tracking NaNs with Prometheus gauge
- provide debug probe and stream runner with defensive checks
- document run steps and common model input issues

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68bfa4ca01508325901b1622deefd646