### PR TITLE
Add alerts, backtesting utility and voter metrics

### DIFF
--- a/alerts.py
+++ b/alerts.py
@@ -1,0 +1,82 @@
+# futu_autotrade/alerts.py
+"""Simple alerting helpers for Telegram and Email.
+Usage:
+  from alerts import send_alert
+  send_alert('RiskLock', {'symbol': 'US.AAPL', 'reason': 'max daily loss'}, cfg)
+Config (config.yaml):
+  alerts:
+    enabled: true
+    throttle_seconds: 60
+    telegram:
+      bot_token: ""
+      chat_id: ""
+    email:
+      smtp_host: "smtp.example.com"
+      smtp_port: 587
+      username: ""
+      password: ""
+      from_addr: "bot@example.com"
+      to_addrs: ["you@example.com"]
+"""
+from __future__ import annotations
+import time, json, smtplib, ssl
+from typing import Dict, Any, List
+
+_last_sent = {}
+
+def _throttle(key: str, seconds: int) -> bool:
+    now = time.time()
+    last = _last_sent.get(key, 0)
+    if now - last < seconds:
+        return True
+    _last_sent[key] = now
+    return False
+
+def _send_telegram(bot_token: str, chat_id: str, text: str) -> tuple[bool, str]:
+    try:
+        import requests
+    except Exception as e:
+        return False, f"requests not installed: {e}"
+    try:
+        url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
+        r = requests.post(url, json={"chat_id": chat_id, "text": text}, timeout=5)
+        if r.status_code != 200:
+            return False, f"telegram http {r.status_code}: {r.text[:200]}"
+        return True, "ok"
+    except Exception as e:
+        return False, f"telegram error: {e}"
+
+def _send_email(cfg: Dict[str, Any], subject: str, text: str) -> tuple[bool, str]:
+    try:
+        host = cfg.get('smtp_host'); port = int(cfg.get('smtp_port', 587))
+        user = cfg.get('username'); pwd = cfg.get('password')
+        from_addr = cfg.get('from_addr'); to_addrs = cfg.get('to_addrs') or []
+        if not (host and user and pwd and from_addr and to_addrs):
+            return False, "email config incomplete"
+        msg = f"From: {from_addr}\nTo: {', '.join(to_addrs)}\nSubject: {subject}\n\n{text}"
+        ctx = ssl.create_default_context()
+        with smtplib.SMTP(host, port, timeout=5) as server:
+            server.starttls(context=ctx)
+            server.login(user, pwd)
+            server.sendmail(from_addr, to_addrs, msg.encode('utf-8'))
+        return True, "ok"
+    except Exception as e:
+        return False, f"email error: {e}"
+
+def send_alert(event: str, payload: Dict[str, Any], cfg: Dict[str, Any]) -> None:
+    a = (cfg or {}).get('alerts') or {}
+    if not a.get('enabled', False):
+        return
+    throttle = int(a.get('throttle_seconds', 60))
+    key = f"{event}:{payload.get('symbol','*')}"
+    if _throttle(key, throttle):
+        return
+    text = f"[{event}]\n" + json.dumps(payload, ensure_ascii=False, indent=2)
+    # Telegram first
+    tcfg = a.get('telegram') or {}
+    if tcfg.get('bot_token') and tcfg.get('chat_id'):
+        _send_telegram(tcfg['bot_token'], tcfg['chat_id'], text)
+    # Email fallback
+    ecfg = a.get('email') or {}
+    if ecfg:
+        _send_email(ecfg, f"[Alert] {event}", text)

--- a/backtest_voter.py
+++ b/backtest_voter.py
@@ -1,0 +1,151 @@
+# futu_autotrade/backtest_voter.py
+"""Walk-forward backtest for rule-voting strategy.
+Usage:
+  python backtest_voter.py --config ./config.yaml --rules ./rules.yaml --symbol US.AAPL --bars 2000 --cost_bps 5
+Outputs (./reports):
+  - backtest_trades.csv
+  - backtest_equity.csv
+  - backtest_summary.md
+  - images/equity_curve.png, images/drawdown.png
+"""
+import argparse, os, math, yaml
+import pandas as pd, numpy as np
+import matplotlib.pyplot as plt
+from data_fetcher import fetch_kline
+from formulas import build_context, load_fundamentals, safe_eval
+from strategies import vote_signal
+
+def load_cfg(path='./config.yaml'):
+    with open(path, 'r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+def load_rules(path: str | None):
+    import yaml
+    if path and os.path.exists(path):
+        with open(path, 'r', encoding='utf-8') as f:
+            dat = yaml.safe_load(f)
+        rules = dat.get('rules', [])
+    else:
+        rules = [
+            {'rule': 'ema_20 > ema_50', 'weight': 1.0},
+            {'rule': 'macd_hist > 0', 'weight': 0.5},
+            {'rule': 'rsi_14 < 70', 'weight': 0.2},
+            {'rule': 'close > sma_50', 'weight': 0.3},
+        ]
+    return {r['rule']: float(r.get('weight', 1.0)) for r in rules}
+
+def metrics(equity: pd.Series, rf: float = 0.0) -> dict:
+    if len(equity) < 2:
+        return {'CAGR': 0, 'Sharpe': 0, 'MDD': 0, 'WinRate': 0, 'Trades': 0}
+    rets = equity.pct_change().fillna(0.0)
+    years = (equity.index[-1] - equity.index[0]).days / 365.25 if hasattr(equity.index[0], 'to_pydatetime') else len(equity) / 252 / 24 / 60
+    cagr = (equity.iloc[-1] / equity.iloc[0]) ** (1 / years) - 1 if years > 0 else 0.0
+    sharpe = (rets.mean() - rf/252) / (rets.std() + 1e-12) * (252 ** 0.5)
+    peak = equity.cummax()
+    dd = (equity / peak - 1.0)
+    mdd = dd.min()
+    return {'CAGR': float(cagr), 'Sharpe': float(sharpe), 'MDD': float(mdd)}
+
+def backtest(df: pd.DataFrame, rules: dict, funds: dict, symbol: str, cost_bps: float = 5.0):
+    pos = 0  # -1,0,1 (long/flat/short). Here we use long/flat only for simplicity.
+    cash = 1.0
+    shares = 0.0
+    trades = []
+    equity = []
+    times = []
+    for i in range(60, len(df)):  # warmup
+        window = df.iloc[:i+1].copy()
+        ctx = build_context(window, fundamentals=funds, symbol=symbol)
+        score = 0.0
+        for expr, w in rules.items():
+            try:
+                if safe_eval(expr, ctx):
+                    score += w
+            except Exception:
+                pass
+        sig = 'BUY' if score > 0 else ('SELL' if score < 0 else 'HOLD')
+        px = float(window['close'].iloc[-1])
+        ts = pd.to_datetime(window['time_key'].iloc[-1])
+        if sig == 'BUY' and pos == 0:
+            qty = cash / px
+            fee = qty * px * cost_bps / 10000.0
+            qty = (cash - fee) / px
+            shares += qty
+            cash -= qty * px + fee
+            pos = 1
+            trades.append({'time': ts, 'side': 'BUY', 'price': px, 'qty': qty, 'score': score})
+        elif sig == 'SELL' and pos == 1:
+            fee = shares * px * cost_bps / 10000.0
+            cash += shares * px - fee
+            trades.append({'time': ts, 'side': 'SELL', 'price': px, 'qty': shares, 'score': score})
+            shares = 0.0
+            pos = 0
+        eq = cash + shares * px
+        equity.append(eq)
+        times.append(ts)
+    eq_series = pd.Series(equity, index=pd.to_datetime(times))
+    return pd.DataFrame(trades), eq_series
+
+def plot_series(s: pd.Series, title: str, path: str):
+    fig = plt.figure()
+    ax = fig.gca()
+    ax.plot(s.index, s.values, label=title)
+    ax.set_title(title)
+    ax.legend()
+    fig.autofmt_xdate()
+    fig.savefig(path, dpi=120, bbox_inches='tight')
+    plt.close(fig)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--config', default='./config.yaml')
+    ap.add_argument('--rules', default='./rules.yaml')
+    ap.add_argument('--symbol', default=None)
+    ap.add_argument('--bars', type=int, default=2000)
+    ap.add_argument('--cost_bps', type=float, default=5.0)
+    ap.add_argument('--out', default='./reports')
+    args = ap.parse_args()
+
+    cfg = load_cfg(args.config)
+    futu = cfg['futu']
+    sym = args.symbol or (cfg.get('symbols')[0] if cfg.get('symbols') else futu['symbol'])
+    rules = load_rules(args.rules)
+    fund_path = os.path.join(os.path.dirname(args.config), 'data', 'fundamentals.csv')
+    if not os.path.exists(fund_path):
+        fund_path = './data/fundamentals.csv'
+    funds = load_fundamentals(fund_path)
+
+    df, err = fetch_kline(futu['host'], futu['port'], sym, futu['ktype'], args.bars, futu['autype'])
+    if err:
+        print('[WARN]', err)
+    trades, equity = backtest(df, rules, funds, sym, args.cost_bps)
+
+    os.makedirs(args.out, exist_ok=True)
+    trades_path = os.path.join(args.out, 'backtest_trades.csv')
+    eq_path = os.path.join(args.out, 'backtest_equity.csv')
+    trades.to_csv(trades_path, index=False)
+    equity.to_csv(eq_path, header=['equity'])
+
+    m = metrics(equity)
+    md = [
+        '# Backtest Summary',
+        '',
+        f'- Symbol: **{sym}**',
+        f'- Bars: {len(df)}',
+        f'- Trades: {len(trades)}',
+        f'- CAGR: {m.get("CAGR", 0):.2%}',
+        f'- Sharpe: {m.get("Sharpe", 0):.2f}',
+        f'- Max Drawdown: {m.get("MDD", 0):.2%}',
+    ]
+    with open(os.path.join(args.out, 'backtest_summary.md'), 'w', encoding='utf-8') as f:
+        f.write('\n'.join(md))
+
+    plot_series(equity, f'Equity Curve ({sym})', os.path.join(args.out, 'images', 'equity_curve.png'))
+    peak = equity.cummax()
+    dd = equity / peak - 1.0
+    plot_series(dd, f'Drawdown ({sym})', os.path.join(args.out, 'images', 'drawdown.png'))
+
+    print('Saved backtest outputs to', args.out)
+
+if __name__ == '__main__':
+    main()

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,24 @@
+futu:
+  host: 127.0.0.1
+  port: 11111
+  ktype: K_1M
+  autype: qfq
+  symbol: US.AAPL
+symbols:
+  - US.AAPL
+
+alerts:
+  enabled: false
+  throttle_seconds: 60
+  min_unrealized_pnl: -200     # 触发PnlDrop告警阈值
+  min_voter_score: -1.0        # 触发ScoreTooLow告警阈值
+  telegram:
+    bot_token: ""
+    chat_id: ""
+  email:
+    smtp_host: "smtp.example.com"
+    smtp_port: 587
+    username: ""
+    password: ""
+    from_addr: "bot@example.com"
+    to_addrs: ["you@example.com"]

--- a/grafana_dashboard.json
+++ b/grafana_dashboard.json
@@ -1,0 +1,13 @@
+{
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Voter Score per Symbol",
+      "id": 99,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        { "expr": "voter_score{symbol=~\"$symbol\"}" }
+      ]
+    }
+  ]
+}

--- a/grafana_dashboard_symbol.json
+++ b/grafana_dashboard_symbol.json
@@ -1,0 +1,13 @@
+{
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Voter Score per Symbol",
+      "id": 99,
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        { "expr": "voter_score{symbol=~\"$symbol\"}" }
+      ]
+    }
+  ]
+}

--- a/voter_signal_runner.py
+++ b/voter_signal_runner.py
@@ -1,0 +1,53 @@
+"""Stub voter signal runner with metrics and alert hooks.
+
+This module demonstrates how a score based "voter" strategy could expose
+Prometheus metrics and trigger alerts when risk thresholds are exceeded.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Any
+
+from prometheus_client import Gauge
+from broker import place_order  # placeholder import for real trade integration
+from alerts import send_alert
+
+# Core gauges
+
+g_sig = Gauge('voter_signal', 'Voter signal: -1 sell, 0 hold, 1 buy', ['symbol'])
+g_score = Gauge('voter_score', 'Voter weighted score', ['symbol'])
+g_rules_eval = Gauge('voter_rules_evaluated', 'Rules evaluated count', ['symbol'])
+g_rules_pass = Gauge('voter_rules_passed', 'Rules passed count', ['symbol'])
+g_fund_missing = Gauge('fundamentals_missing_fields', 'Missing fundamentals fields count', ['symbol'])
+g_pnl = Gauge('voter_unrealized_pnl', 'Unrealized PnL', ['symbol'])
+
+def run_once(sym: str, score: float, pnl: float, cfg: Dict[str, Any]) -> None:
+    """Update metrics for ``sym`` and trigger alerts if thresholds breached."""
+    sig = 'BUY' if score > 0 else ('SELL' if score < 0 else 'HOLD')
+    g_sig.labels(symbol=sym).set({'BUY': 1, 'SELL': -1}.get(sig, 0))
+    g_score.labels(symbol=sym).set(score)
+    g_rules_eval.labels(symbol=sym).set(0)
+    g_rules_pass.labels(symbol=sym).set(0)
+    g_fund_missing.labels(symbol=sym).set(0)
+    g_pnl.labels(symbol=sym).set(pnl)
+
+    al = cfg.get('alerts', {})
+    min_pnl = float(al.get('min_unrealized_pnl', -999999))
+    min_score = float(al.get('min_voter_score', -9e9))
+    if al.get('enabled', False):
+        if pnl <= min_pnl:
+            send_alert('PnLDrop', {'symbol': sym, 'pnl': pnl}, cfg)
+        if score <= min_score:
+            send_alert('ScoreTooLow', {'symbol': sym, 'score': score}, cfg)
+
+def main():
+    cfg = {}
+    cfg_path = Path('config.yaml')
+    if cfg_path.exists():
+        import yaml
+        cfg = yaml.safe_load(cfg_path.read_text())
+    # Example demo call
+    run_once('DEMO', 0.5, -100.0, cfg)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Telegram/Email alert helper
- expose voter score metrics and alerts for low score or PnL
- add walk-forward backtest script and dashboards

## Testing
- `python -m py_compile alerts.py voter_signal_runner.py backtest_voter.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfa7df4eb0832588c5adee1419fcd4